### PR TITLE
Ajout du nombre de tours en dessous du combat

### DIFF
--- a/LeekWars_Fast_Garden.user.js
+++ b/LeekWars_Fast_Garden.user.js
@@ -102,6 +102,8 @@ function checkFightResult(fight)
             console.log("Egalité !");
             fight.result = ResultEnum.EQUALITY;
             if (el) el.style.backgroundColor = ColorEnum.EQUALITY;
+            el.title = "Durée : 64 Tours";
+            $('<div>').appendTo(el).html(el.title);
             return;
           }
           var i3 = res.indexOf("<div id='duration'>") + 19;
@@ -111,7 +113,11 @@ function checkFightResult(fight)
             duration = $("<div/>").html(duration).text();
           console.log(duration);
           fight.descTurns = duration;
-          if (el) el.title = duration;
+          if (el)
+          {
+              el.title = duration;
+              $('<div>').appendTo(el).html(duration);
+          }
           var index = -1;
           if (fight.type == FightTypeEnum.SOLO)
             index = res.indexOf("<a href='/leek/" + fight.myId, i1);


### PR DESCRIPTION
J'ai fais une petite amélioration, on peut voir le nombre de tours après chaque combat.
Pas besoin de laisser la console ouverte, on peut voir si le match a été difficile ou non.
![capture](https://cloud.githubusercontent.com/assets/6797195/4692768/c176015c-5778-11e4-9781-89065c7dd7a3.PNG)
