### PR TITLE
Ajout d'un bouton pour voir le rapport de combat, possibilité de relance...

### DIFF
--- a/LeekWars_Fast_Garden.user.js
+++ b/LeekWars_Fast_Garden.user.js
@@ -46,16 +46,6 @@ window.submitForm = function(page, params){
     console.log('Combat annulé car de type inconnu');
     return;
   }
-  //vérifier si combat déjà lancé
-  for (var i = 0; i < fights.length; i++) {
-    if (fights[i].targetId == targetId) {
-      //si terminé ouvrir le rapport dans un nouvel onglet, sinon ne rien faire
-      if (fights[i].result != ResultEnum.UNDEFINED) {
-        window.open('/report/' + fights[i].fightId, '_blank');
-      }
-      return;
-    }
-  }
   console.log('Lancement du combat contre ' + name + '...');
   //petit changement d'apparence pour indiquer qu'un combat est lancé
   var el = $('#' + targetId)[0];
@@ -141,6 +131,24 @@ function checkFightResult(fight)
             console.log("Défaite !");
             fight.result = ResultEnum.DEFEAT;
             if (el) el.style.backgroundColor = ColorEnum.DEFEAT;
+          }
+          if (el) 
+          {
+            // Mise à jour du lien du rapport
+            var report = $("#report",el)[0];
+            if(typeof(report) != "undefined")
+            {
+              $(report).off('click')
+            }
+            else
+            {
+              $("<br>").appendTo(el);
+              report = $('<div class="button" id="report">').appendTo(el).html("Rapport de combat");
+            }
+            $(report).on('click',function(e){
+              e.stopPropagation();
+              window.open('/report/' + fight.fightId, '_blank');
+            });
           }
         }
   });

--- a/LeekWars_Fast_Garden.user.js
+++ b/LeekWars_Fast_Garden.user.js
@@ -143,7 +143,7 @@ function checkFightResult(fight)
             else
             {
               $("<br>").appendTo(el);
-              report = $('<div class="button" id="report">').appendTo(el).html("Rapport de combat");
+              report = $('<img src="http://static.leekwars.com/image/fight_black.png" id="report">').appendTo(el).html("Rapport de combat");
             }
             $(report).on('click',function(e){
               e.stopPropagation();


### PR DESCRIPTION
Maintenant on peut voir le dernier rapport de combat en cliquant sur le bouton,
ou on peut relancer un nouveau combat en cliquant comme d'habitude.
![capture](https://cloud.githubusercontent.com/assets/6797195/4692993/e6747a2c-5784-11e4-8997-257eb416c289.PNG)
